### PR TITLE
Capability to set / remove comment lines, parse mode normal / numeric only / raw

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ composer require "jelix/inifile"
 # Usage
 
 The ```\Jelix\IniFile\IniModifier``` class allows to read an ini file, to modify its
-content, and save it by preserving its comments and empty lines.
+content including comments, and save it by preserving empty lines.
 
 Don't use this class to just read content. Use instead ```\Jelix\IniFile\Util``` or
 ```parse_ini_file()``` for this purpose, it's more efficient and performant.
@@ -32,9 +32,17 @@ $val = $ini->getValue('parameter_name', 'section_name');
 // remove a parameter
 $ini->removeValue('parameter_name', 'section_name');
 
+// setting a comment (in the line preceding the parameter) - the leading ';'
+// can be omitted or included in the comment line, if missing will be added
+$ini->setComments('parameter_name', '; single-line comment text', 'section_name');
+
+// setting a multi-line comment (in the lines preceding the parameter)
+$ini->setComments('parameter_name', [ 'first line', 'second line' ], 'section_name');
+
+// remove all comment lines preceding a parameter
+$ini->removeComments('parameter_name', 'section_name');
 
 // save into file
-
 $ini->save();
 $ini->saveAs('otherfile.ini');
 
@@ -49,6 +57,8 @@ $ini->mergeSection('sectionSource', 'sectionTarget');
 
 ```
 
+It support parsing of parameter values into PHP types (string, numeric, boolean) as well as 
+
 It supports also array values (indexed or associative) like :
 
 ```
@@ -60,7 +70,7 @@ assoc[otherkey]=bus
 
 Then in PHP:
 
-```
+```php
 $ini = new \Jelix\IniFile\IniModifier('myfile.ini');
 
 $val = $ini->getValue('foo'); // array('bar', 'baz');
@@ -72,14 +82,13 @@ $val = $ini->getValue('foo'); // array('bar', 'baz', 'other value');
 $ini->setValue('foo', 'five', 0, 5);
 $val = $ini->getValue('foo'); // array('bar', 'baz', 'other value', 5 => 'five');
 
-
 $ini->setValue('assoc', 'other value', 0, 'ov');
 $val = $ini->getValue('assoc'); // array('key1'=>'car', 'otherkey'=>'bus', 'ov'=>'other value');
 ```
 
 After saving, the ini content is:
 
-```
+```ini
 foo[]=bar
 foo[]=baz
 assoc[key1]=car

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "rik72/inifile",
+    "name": "jelix/inifile",
     "type": "library",
     "description": "classes to read and modify ini files by preserving comments and empty lines",
     "keywords": ["ini", "files"],
-    "homepage": "https://github.com/rik72/inifile",
+    "homepage": "https://github.com/jelix/inifile",
     "license": "LGPL-2.1",
     "authors": [
         {
@@ -14,8 +14,7 @@
             "name": "Loic Mathaud"
         },
         {
-            "name": "Riccardo Mazzei",
-            "email": "riccardo.mazzei@gmail.com"
+            "name": "Riccardo Mazzei"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "jelix/inifile",
+    "name": "rik72/inifile",
     "type": "library",
     "description": "classes to read and modify ini files by preserving comments and empty lines",
     "keywords": ["ini", "files"],
-    "homepage": "http://jelix.org",
+    "homepage": "https://github.com/rik72/inifile",
     "license": "LGPL-2.1",
     "authors": [
         {
@@ -12,6 +12,10 @@
         },
         {
             "name": "Loic Mathaud"
+        },
+        {
+            "name": "Riccardo Mazzei",
+            "email": "riccardo.mazzei@gmail.com"
         }
     ],
     "require": {

--- a/lib/IniModifier.php
+++ b/lib/IniModifier.php
@@ -30,8 +30,9 @@ class IniModifier extends IniReader implements IniModifierInterface
      * @param string $initialContent if the file does not exists, it takes the given content
      *                               as initial content.
      */
-    public function __construct($filename, $initialContent = '')
+    public function __construct($filename, $initialContent = '', $parsemode = static::PR_NORMAL)
     {
+        $this->parsemode = $parsemode;
         if (!$filename) {
             throw new IniInvalidArgumentException('Filename should not be empty');
         }
@@ -572,13 +573,18 @@ class IniModifier extends IniReader implements IniModifierInterface
                 return "on";
             }
         }
-        if ($value === '' ||
-            is_numeric(trim($value)) ||
-            (is_string($value) && preg_match('/^[\\w\\-\\.]*$/u', $value) &&
-                strpos("\n", $value) === false)
-        ) {
-            return $value;
-        } else {
+        if ($this->parsemode === static::PR_NORMAL) {
+            if ($value === '' ||
+                is_numeric(trim($value)) ||
+                (is_string($value) && preg_match('/^[\\w\\-\\.]*$/u', $value) &&
+                    strpos("\n", $value) === false)
+            ) {
+                return trim($value);
+            } else {
+                $value = '"'.$value.'"';
+            }
+        }
+        else {
             $value = '"'.$value.'"';
         }
 

--- a/lib/IniModifier.php
+++ b/lib/IniModifier.php
@@ -585,7 +585,13 @@ class IniModifier extends IniReader implements IniModifierInterface
             }
         }
         else {
-            $value = '"'.$value.'"';
+            if ($value === '' ||
+                is_numeric(trim($value))
+            ) {
+                return trim($value);
+            } else {
+                $value = '"'.$value.'"';
+            }
         }
 
         return $value;

--- a/lib/IniModifier.php
+++ b/lib/IniModifier.php
@@ -132,7 +132,16 @@ class IniModifier extends IniReader implements IniModifierInterface
         }
         if (!$foundValue) {
             if ($key === null) {
-                $this->content[$section][] = array(self::TK_VALUE, $name, $value);
+                if ($this->content[$section]) {
+                    for ($pos = count($this->content[$section]) - 1; $pos >= 0; $pos--) {
+                        if ($this->content[$section][$pos][0] !== self::TK_WS && $this->content[$section][$pos][0] !== self::TK_COMMENT) {
+                            array_splice($this->content[$section], $pos + 1, 0, array(array(self::TK_VALUE, $name, $value)));
+                            break;
+                        }
+                    }
+                } else {
+                    $this->content[$section][] = array(self::TK_VALUE, $name, $value);
+                }
             } else {
                 if ($key === '') {
                     if ($lastKey != -1) {
@@ -141,7 +150,16 @@ class IniModifier extends IniReader implements IniModifierInterface
                         $key = 0;
                     }
                 }
-                $this->content[$section][] = array(self::TK_ARR_VALUE, $name, $value, $key);
+                if ($this->content[$section]) {
+                    for ($pos = count($this->content[$section]) - 1; $pos >= 0; $pos--) {
+                        if ($this->content[$section][$pos][0] !== self::TK_WS && $this->content[$section][$pos][0] !== self::TK_COMMENT) {
+                            array_splice($this->content[$section], $pos + 1, 0, array(array(self::TK_ARR_VALUE, $name, $value, $key)));
+                            break;
+                        }
+                    }
+                } else {
+                    $this->content[$section][] = array(self::TK_ARR_VALUE, $name, $value, $key);
+                }
             }
             $this->modified = true;
         }
@@ -293,6 +311,129 @@ class IniModifier extends IniReader implements IniModifierInterface
                     }
                 }
                 break;
+            }
+        }
+    }
+
+    /**
+     * create or replace comment lines preceding an option.
+     *
+     * @param string $name      the name of the option to find
+     * @param mixed  $comments  comment line (if string) or array of lines.
+     * @param string $section   the section where to find the item to add/set the comments to. 0 is the global section
+     * @param int    $key       for option which is an item of array, the key in the array.
+     */
+    public function setComments($name, $comments, $section = 0, $key = null)
+    {
+        $this->_setOrRemoveComments($name, $section, $key, $comments);
+    }
+
+    /**
+     * remove comment lines preceding an option.
+     *
+     * @param string $name      the name of the option to find
+     * @param string $section   the section where to set the item. 0 is the global section
+     * @param int    $key       for option which is an item of array, the key in the array.
+     */
+    public function removeComments($name, $section = 0, $key = null)
+    {
+        $this->_setOrRemoveComments($name, $section, $key, $comments = null);
+    }
+
+    protected function _setOrRemoveComments($name, $section = 0, $key = null, $comments = null)
+    {
+        if (is_string($key) && !preg_match('/^[^\\[\\]]*$/', $key)) {
+            throw new IniInvalidArgumentException("Invalid key $key for the value $name");
+        }
+
+        if ($comments) {
+            if (!is_array($comments)) {
+                $comments = array($comments);
+            }
+
+            foreach ($comments as $i => $comment) {
+                if (!str_starts_with($comment, ';')) {
+                    $comments[$i] = ';' . $comments[$i];
+                }
+                $comments[$i] = array(self::TK_COMMENT, $comments[$i]);
+            }
+        }
+
+        if ($name == '') {
+            // retrieve the previous section
+            $previousSection = -1;
+            foreach ($this->content as $s => $c) {
+                if ($s === $section) {
+                    break;
+                } else {
+                    $previousSection = $s;
+                }
+            }
+
+            if ($previousSection != -1) {
+                //retrieve the last comment
+                $s = $this->content[$previousSection];
+                end($s);
+                $tok = current($s);
+                while ($tok !== false) {
+                    if ($tok[0] != self::TK_COMMENT) {
+                        break;
+                    }
+                    if ($tok[0] == self::TK_COMMENT && strpos($tok[1], '<?') === false) {
+                        $this->content[$previousSection][key($s)] = array(self::TK_WS, '--');
+                    }
+                    $tok = prev($s);
+                }
+                if ($comments) {
+                    foreach ($comments as $comment) {
+                        $this->content[$previousSection][] = $comment;
+                    }
+                }
+            }
+            return;
+        }
+
+        if (isset($this->content[$section])) {
+            // boolean to erase array values if the option to remove is an array
+            $previousComment = array();
+            foreach ($this->content[$section] as $k => $item) {
+                if ($item[0] == self::TK_COMMENT) {
+                    $previousComment[] = $k;
+                    continue;
+                }
+
+                if ($item[0] == self::TK_WS) {
+                    continue;
+                }
+
+                // if the item is not a value or an array value, or not the same name
+                if ($item[1] != $name) {
+                    $previousComment = array();
+                    continue;
+                }
+
+                // if it is an array value, and if the key doesn't correspond
+                if ($item[0] == self::TK_ARR_VALUE && $key !== null) {
+                    if ($item[3] != $key) {
+                        $previousComment = array();
+                        continue;
+                    }
+                }
+                $this->modified = true;
+                if (count($previousComment)) {
+                    $kc = array_pop($previousComment);
+
+                    $lastKc = -1;
+                    while ($kc !== null) {
+                        if (strpos($this->content[$section][$kc][1], '<?') === false) {
+                            $this->content[$section][$kc] = array(self::TK_WS, '--');
+                        }
+                        $kc = array_pop($previousComment);
+                    }
+                }
+                if ($comments) {
+                    array_splice($this->content[$section], $k, 0, $comments);
+                }
             }
         }
     }

--- a/lib/IniModifier.php
+++ b/lib/IniModifier.php
@@ -30,7 +30,7 @@ class IniModifier extends IniReader implements IniModifierInterface
      * @param string $initialContent if the file does not exists, it takes the given content
      *                               as initial content.
      */
-    public function __construct($filename, $initialContent = '', $parsemode = static::PR_NORMAL)
+    public function __construct($filename, $initialContent = '', $parsemode = parent::PR_NORMAL)
     {
         $this->parsemode = $parsemode;
         if (!$filename) {
@@ -213,7 +213,7 @@ class IniModifier extends IniReader implements IniModifierInterface
     /**
      * modify several options in the ini file.
      *
-     * @param array  $value   associated array with key=>value
+     * @param array  $values   associated array with key=>value
      * @param string $section the section where to set the item. 0 is the global section
      */
     public function setValues($values, $section = 0)
@@ -573,7 +573,7 @@ class IniModifier extends IniReader implements IniModifierInterface
                 return "on";
             }
         }
-        if ($this->parsemode === static::PR_NORMAL) {
+        if ($this->parsemode === parent::PR_NORMAL) {
             if ($value === '' ||
                 is_numeric(trim($value)) ||
                 (is_string($value) && preg_match('/^[\\w\\-\\.]*$/u', $value) &&

--- a/lib/IniModifierArray.php
+++ b/lib/IniModifierArray.php
@@ -112,7 +112,7 @@ class IniModifierArray implements IniModifierInterface, \IteratorAggregate, \Arr
     /**
      * modify several options in the latest ini file.
      *
-     * @param array  $value   associated array with key=>value
+     * @param array  $values   associated array with key=>value
      * @param string $section the section where to set the item. 0 is the global section
      */
     public function setValues($values, $section = 0)

--- a/lib/IniModifierArray.php
+++ b/lib/IniModifierArray.php
@@ -202,6 +202,40 @@ class IniModifierArray implements IniModifierInterface, \IteratorAggregate, \Arr
     }
 
     /**
+     * create or replace comment lines preceding an option from all ini file.
+     *
+     * @param string $name      the name of the option to find
+     * @param mixed  $comments  comment line content (if string) or array of lines contents. Each line
+     *                          will be prepended with ";" if needed
+     * @param string $section   the section where to set the item. 0 is the global section
+     * @param int    $key       for option which is an item of array, the key in the array.
+     */
+    public function setComments($name, $comments, $section = 0, $key = null)
+    {
+        foreach ($this->modifiers as $mod) {
+            if ($mod instanceof IniModifierInterface) {
+                $mod->setComments($name, $comments, $section, $key);
+            }
+        }
+    }
+
+    /**
+     * remove comment lines preceding an option from all ini file.
+     *
+     * @param string $name      the name of the option to find
+     * @param string $section   the section where to set the item. 0 is the global section
+     * @param int    $key       for option which is an item of array, the key in the array.
+     */
+    public function removeComments($name, $section = 0, $key = null)
+    {
+        foreach ($this->modifiers as $mod) {
+            if ($mod instanceof IniModifierInterface) {
+                $mod->removeComments($name, $section, $key);
+            }
+        }
+    }
+
+    /**
      * remove a section from all ini file.
      * @param int $section
      * @param bool $removePreviousComment

--- a/lib/IniModifierInterface.php
+++ b/lib/IniModifierInterface.php
@@ -29,7 +29,7 @@ interface IniModifierInterface extends IniReaderInterface
     /**
      * modify several options in the ini file.
      *
-     * @param array  $value   associated array with key=>value
+     * @param array  $values   associated array with key=>value
      * @param string $section the section where to set the item. 0 is the global section
      */
     public function setValues($values, $section = 0);

--- a/lib/IniModifierInterface.php
+++ b/lib/IniModifierInterface.php
@@ -49,6 +49,26 @@ interface IniModifierInterface extends IniReaderInterface
     public function removeValue($name, $section = 0, $key = null, $removePreviousComment = true);
 
     /**
+     * create or replace comment lines preceding an option.
+     *
+     * @param string $name      the name of the option to find
+     * @param mixed  $comments  comment line content (if string) or array of lines contents. Each line
+     *                          will be prepended with ";" if needed
+     * @param string $section   the section where to set the item. 0 is the global section
+     * @param int    $key       for option which is an item of array, the key in the array.
+     */
+    public function setComments($name, $comments, $section = 0, $key = null);
+
+    /**
+     * remove comment lines preceding an option.
+     *
+     * @param string $name      the name of the option to find
+     * @param string $section   the section where to set the item. 0 is the global section
+     * @param int    $key       for option which is an item of array, the key in the array.
+     */
+    public function removeComments($name, $section = 0, $key = null);
+
+    /**
      * remove a section from the ini file.
      *
      * @param string $section the section where to remove the value, or the section to remove

--- a/lib/IniReader.php
+++ b/lib/IniReader.php
@@ -29,7 +29,7 @@ class IniReader implements IniReaderInterface
     /**
      * @const integer parse mode raw
      */
-    const PR_NORMAL = 1;
+    const PR_RAW = 1;
 
     /**
      * @const integer token type for whitespaces

--- a/lib/IniReader.php
+++ b/lib/IniReader.php
@@ -20,7 +20,17 @@ namespace Jelix\IniFile;
  * read ini content, use parse_ini_file, it's better in term of performance.
  */
 class IniReader implements IniReaderInterface
-{
+{  
+    /**
+     * @const integer parse mode normal
+     */
+    const PR_NORMAL = 0;
+
+    /**
+     * @const integer parse mode raw
+     */
+    const PR_NORMAL = 1;
+
     /**
      * @const integer token type for whitespaces
      */
@@ -41,6 +51,12 @@ class IniReader implements IniReaderInterface
      * @const integer token type for a value of an array item
      */
     const TK_ARR_VALUE = 4;
+
+    /**
+     * the parse mode: PR_NORMAL for normal, typed parsing, PR_RAW for raw (only numeric fields are typed)
+     * @var int
+     */
+    protected $parsemode;
 
     /**
      * each item of this array contains data for a section. the key of the item
@@ -69,8 +85,9 @@ class IniReader implements IniReaderInterface
      *
      * @param string $filename the file to load
      */
-    public function __construct($filename)
+    public function __construct($filename, $parsemode = self::PR_NORMAL)
     {
+        $this->parsemode = $parsemode;
         if (!file_exists($filename) || !is_file($filename)) {
             throw new IniInvalidArgumentException("The file $filename does not exists");
         }
@@ -235,12 +252,14 @@ class IniReader implements IniReaderInterface
         }
         if (preg_match('/^-?[0-9]$/', $value)) {
             return intval($value);
-        } elseif (preg_match('/^-?[0-9\.]$/', $value)) {
-            return floatval($value);
-        } elseif (strtolower($value) === 'true' || strtolower($value) === 'on' || strtolower($value) === 'yes') {
-            return true;
-        } elseif (strtolower($value) === 'false' || strtolower($value) === 'off' || strtolower($value) === 'no' || strtolower($value) === 'none') {
-            return false;
+        } elseif ($this->parsemode === self::PR_NORMAL ) {
+            if (preg_match('/^-?[0-9\.]$/', $value)) {
+                return floatval($value);
+            } elseif (strtolower($value) === 'true' || strtolower($value) === 'on' || strtolower($value) === 'yes') {
+                return true;
+            } elseif (strtolower($value) === 'false' || strtolower($value) === 'off' || strtolower($value) === 'no' || strtolower($value) === 'none') {
+                return false;
+            }
         }
         return $value;
     }

--- a/lib/MultiIniModifier.php
+++ b/lib/MultiIniModifier.php
@@ -214,6 +214,67 @@ class MultiIniModifier implements IniModifierInterface
         $this->master->removeValue($name, $section, $key, $removePreviousComment);
     }
 
+    /**
+     * create or replace comment lines preceding an option in the overrider ini file.
+     *
+     * @param string $name      the name of the option to find
+     * @param mixed  $comments  comment line content (if string) or array of lines contents. Each line
+     *                          will be prepended with ";" if needed
+     * @param string $section   the section where to set the item. 0 is the global section
+     * @param int    $key       for option which is an item of array, the key in the array.
+     */
+    public function setComments($name, $comments, $section = 0, $key = null)
+    {
+        $this->overrider->setComments($name, $comments, $section, $key);
+    }
+
+    /**
+     * create or replace comment lines preceding an option in the overrider ini file.
+     *
+     * @param string $name      the name of the option to find
+     * @param mixed  $comments  comment line content (if string) or array of lines contents. Each line
+     *                          will be prepended with ";" if needed
+     * @param string $section   the section where to set the item. 0 is the global section
+     * @param int    $key       for option which is an item of array, the key in the array.
+     */
+    public function setCommentsOnMaster($name, $comments, $section = 0, $key = null)
+    {
+        if (!$this->master instanceof IniModifierInterface) {
+            throw new IniException('Cannot set comments on master which is only an ini reader');
+        }
+        $this->master->setComments($name, $comments, $section, $key);
+    }
+
+    /**
+     * remove comment lines preceding an option from the two ini file.
+     *
+     * @param string $name      the name of the option to find
+     * @param string $section   the section where to set the item. 0 is the global section
+     * @param int    $key       for option which is an item of array, the key in the array.
+     */
+    public function removeComments($name, $section = 0, $key = null)
+    {
+        if ($this->master instanceof IniModifierInterface) {
+            $this->master->removeComments($name, $section, $key);
+        }
+        $this->overrider->removeComments($name, $section, $key);
+    }
+
+    /**
+     * remove comment lines preceding an option from master ini file only.
+     *
+     * @param string $name      the name of the option to find
+     * @param string $section   the section where to set the item. 0 is the global section
+     * @param int    $key       for option which is an item of array, the key in the array.
+     */
+    public function removeCommentsOnMaster($name, $section = 0, $key = null)
+    {
+        if ($this->master instanceof IniModifierInterface) {
+            throw new IniException('Cannot remove comments on master which is only an ini reader');
+        }
+        $this->master->removeComments($name, $section, $key);
+    }
+
 
     /**
      * remove a section from the two ini file.

--- a/lib/MultiIniModifier.php
+++ b/lib/MultiIniModifier.php
@@ -91,7 +91,7 @@ class MultiIniModifier implements IniModifierInterface
     /**
      * modify several options in the overrider ini file.
      *
-     * @param array  $value   associated array with key=>value
+     * @param array  $values   associated array with key=>value
      * @param string $section the section where to set the item. 0 is the global section
      */
     public function setValues($values, $section = 0)
@@ -102,7 +102,7 @@ class MultiIniModifier implements IniModifierInterface
     /**
      * modify several options in the master ini file.
      *
-     * @param array  $value   associated array with key=>value
+     * @param array  $values   associated array with key=>value
      * @param string $section the section where to set the item. 0 is the global section
      */
     public function setValuesOnMaster($values, $section = 0)

--- a/tests/IniModifierNormalGetTest.php
+++ b/tests/IniModifierNormalGetTest.php
@@ -10,7 +10,7 @@ use \Jelix\IniFile\MultiIniModifier as MultiIniModifier;
 
 require_once(__DIR__.'/lib.php');
 
-class IniModifierGetTest extends PHPUnit_Framework_TestCase {
+class IniModifierNormalGetTest extends PHPUnit_Framework_TestCase {
 
     function testGetValue() {
         $parser = new testIniFileModifier('foo.ini', '
@@ -18,6 +18,7 @@ class IniModifierGetTest extends PHPUnit_Framework_TestCase {
   
 foo=bar
 anumber=98
+anumber_string = "98"
 string= "uuuuu"
 string2= "aaa
 bbb"
@@ -25,6 +26,7 @@ string3= "aaa
   multiline
 bbb"
 afloatnumber=   5.098  
+afloatnumber_string = "5.098"
 
 [aSection]
 laurent=toto
@@ -57,6 +59,7 @@ foo[key3]=ccc
 
         $this->assertEquals($parser->getValue('foo'), 'bar' );
         $this->assertEquals($parser->getValue('anumber'), 98 );
+        $this->assertEquals($parser->getValue('anumber_string'), 98 );
         $this->assertEquals($parser->getValue('string'), 'uuuuu' );
         $this->assertEquals($parser->getValue('string2'), 'aaa
 bbb');
@@ -64,6 +67,7 @@ bbb');
   multiline
 bbb');
         $this->assertEquals($parser->getValue('afloatnumber'), 5.098 );
+        $this->assertEquals($parser->getValue('afloatnumber_string'), 5.098 );
         $this->assertEquals($parser->getValue('truc','aSection'), null );
         $this->assertEquals($parser->getValue('laurent','aSection'), 'toto' );
         $this->assertEquals($parser->getValue('trucon','aSection'), true );

--- a/tests/IniModifierNormalSetTest.php
+++ b/tests/IniModifierNormalSetTest.php
@@ -1,0 +1,788 @@
+<?php
+/**
+ * @author      Laurent Jouanneau
+ * @copyright   2008-2016 Laurent Jouanneau
+ * @link        http://www.jelix.org
+ * @licence     GNU Lesser General Public Licence see LICENCE file or http://www.gnu.org/licenses/lgpl.html
+ */
+use \Jelix\IniFile\IniModifier as IniModifier;
+use \Jelix\IniFile\MultiIniModifier as MultiIniModifier;
+
+require_once(__DIR__ . '/lib.php');
+
+class IniModifierNormalSetTest extends PHPUnit_Framework_TestCase
+{
+
+    protected function prepareParserSetValue()
+    {
+        $content = '
+  ; a comment
+  
+foo=bar
+
+[aSection]
+truc=machin
+flag=on
+noflag=off
+
+[othersection]
+truc=machin2
+
+';
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $parser = new testIniFileModifier('foo.ini', $content);
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertFalse($parser->isModified());
+        return $parser;
+    }
+
+    function testSetValue()
+    {
+        $parser = $this->prepareParserSetValue();
+        // set Simple value
+        $parser->setValue('foo', 'hello');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'hello'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // set value in a section
+        $parser->setValue('truc', 'bidule', 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'hello'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'bidule'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // set value in an other section
+        $parser->setValue('truc', 'bidule2', 'othersection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'hello'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'bidule'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'bidule2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        $parser->setValue('name', 'toto', 'othersection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'hello'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'bidule'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'bidule2'),
+                array(IniModifier::TK_VALUE, 'name', 'toto'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+
+    function testSetExistingValue()
+    {
+        $parser = $this->prepareParserSetValue();
+        // set Simple value
+        $parser->setValue('foo', 'bar');
+        $parser->setValue('flag', true, 'aSection');
+        $parser->setValue('noflag', false, 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertFalse($parser->isModified());
+
+        // set same value in a section
+        $parser->setValue('truc', 'machin', 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertFalse($parser->isModified());
+
+        // set modified value in a section
+        $parser->setValue('truc', 'bidule', 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'bidule'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+
+        $parser = $this->prepareParserSetValue();
+        // set modified boolean value
+        $parser->setValue('flag', false, 'aSection');
+        $parser->setValue('noflag', true, 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', false),
+                array(IniModifier::TK_VALUE, 'noflag', true),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+
+        $parser = $this->prepareParserSetValue();
+        // set Simple value
+        $parser->setValue('flag', 'off', 'aSection');
+        $parser->setValue('noflag', 'on', 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'off'),
+                array(IniModifier::TK_VALUE, 'noflag', 'on'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $this->assertFalse($parser->getValue('flag', 'aSection'));
+        $this->assertTrue($parser->getValue('noflag', 'aSection'));
+    }
+
+
+    function testSetArrayValue()
+    {
+        $parser = $this->prepareParserSetValue();
+        // append an array value
+        $parser->setValue('name', 'toto', 'othersection', '');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'toto', 0),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // append an array value at the 0 key
+        $parser->setValue('theme', 'blue', 'aSection', 0);
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_ARR_VALUE, 'theme', 'blue', 0),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'toto', 0),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+
+    function testSetArrayValue2()
+    {
+        $content = '
+foo[]=bar
+example=1
+foo[]=machine
+';
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 1),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $parser = new testIniFileModifier('foo.ini', $content);
+        $this->assertEquals($expected, $parser->getContent());
+
+        $parser->setValue('foo', 'bla', 0, '');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 1),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bla', 2),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        $parser->setValue('theme', 'blue', 'aSection', '0');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 1),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bla', 2),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_ARR_VALUE, 'theme', 'blue', 0),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        $parser->setValue('foo', 'button');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_VALUE, 'foo', 'button'),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_WS, '--'),
+                array(IniModifier::TK_WS, '--'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_ARR_VALUE, 'theme', 'blue', 0),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+
+
+    function testSetArrayValueWithArray()
+    {
+        $parser = $this->prepareParserSetValue();
+        // append an array value
+        $parser->setValue('name', 'toto', 'othersection', '');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'toto', 0),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // now set a new value which is an array
+        $parser->setValue('name', array('black', 'brown', 'yellow'), 'othersection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'black', 0),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'brown', 1),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'yellow', 2),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // now change it by a smaller array
+        $parser->setValue('name', array('red', 'white'), 'othersection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'red', 0),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'white', 1),
+                array(IniModifier::TK_WS, '--'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+
+    function testModifyArrayValueWithArray()
+    {
+        $content = '
+  ; a comment
+  
+foo=bar
+
+[aSection]
+truc=machin
+mylist[]=hello
+ddd=eee
+mylist[]=bar
+fff=ggg
+
+[othersection]
+truc=machin2
+
+';
+        $parser = new testIniFileModifier('foo.ini', $content);
+
+        // now set a new value which is an array
+        $parser->setValue('mylist', array('black', 'brown', 'yellow'), 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_ARR_VALUE, 'mylist', 'black', 0),
+                array(IniModifier::TK_VALUE, 'ddd', 'eee'),
+                array(IniModifier::TK_ARR_VALUE, 'mylist', 'brown', 1),
+                array(IniModifier::TK_VALUE, 'fff', 'ggg'),
+                array(IniModifier::TK_ARR_VALUE, 'mylist', 'yellow', 2),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // now change it by a smaller array
+        $parser->setValue('mylist', array('red'), 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_ARR_VALUE, 'mylist', 'red', 0),
+                array(IniModifier::TK_VALUE, 'ddd', 'eee'),
+                array(IniModifier::TK_WS, '--'),
+                array(IniModifier::TK_VALUE, 'fff', 'ggg'),
+                array(IniModifier::TK_WS, '--'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+    }
+
+    function testSetAssocArrayValue()
+    {
+        $content = '
+foo[]=bar
+example=1
+foo[key1]=machine
+foo[]=vla
+';
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 'key1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'vla', 2),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $parser = new testIniFileModifier('foo.ini', $content);
+        $this->assertEquals($expected, $parser->getContent());
+
+        $parser->setValue('foo', 'bla', 0, 'champ');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 'key1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'vla', 2),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bla', 'champ'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        $parser->setValue('foo', 'modif', 0, 'key1');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'modif', 'key1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'vla', 2),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bla', 'champ'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        $parser->setValue('foo', 'modif2', 0, 'champ');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'modif', 'key1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'vla', 2),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'modif2', 'champ'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+
+
+    public function testSetValues() {
+        $content = '
+; a comment <?php die()
+  
+foo=bar
+
+; section comment
+[aSection]
+truc=true
+
+; super section
+[the_section]
+foo= z
+';
+        $ini = new testIniFileModifier('foo.ini', $content);
+        $ini->setValues(
+            array(
+                'truc'=>'machin',
+                'bidule'=>1,
+                'truck'=>true,
+                'notruck'=>false,
+                'foo'=>array('aaa', 'bbb', 'machin'=>'ccc')
+            ),
+            'the_section');
+        $expected = '
+; a comment <?php die()
+  
+foo=bar
+
+; section comment
+[aSection]
+truc=true
+
+; super section
+[the_section]
+truc=machin
+bidule=1
+truck=on
+notruck=off
+foo[]=aaa
+foo[]=bbb
+foo[machin]=ccc
+';
+        $this->assertEquals($expected, $ini->generate());
+        $this->assertTrue($ini->isModified());
+        $ini->clearModifierFlag();
+    }
+
+
+
+    public function testSetExample() {
+        $content = 'foo[]=bar
+foo[]=baz
+assoc[key1]=car
+assoc[otherkey]=bus
+';
+        $ini = new testIniFileModifier('foo.ini', $content);
+        $ini->setValue('foo', 'other value', 0, '');
+        $ini->setValue('foo', 'five', 0, 5);
+        $ini->setValue('assoc', 'other value', 0, 'ov');
+        $expected = 'foo[]=bar
+foo[]=baz
+assoc[key1]=car
+assoc[otherkey]=bus
+foo[]="other value"
+foo[]=five
+assoc[ov]="other value"
+';
+        $this->assertEquals($expected, $ini->generate());
+        $this->assertTrue($ini->isModified());
+        $ini->clearModifierFlag();
+    }
+
+}

--- a/tests/IniModifierNumericGetTest.php
+++ b/tests/IniModifierNumericGetTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * @author      Laurent Jouanneau
+ * @copyright   2008-2015 Laurent Jouanneau
+ * @link        http://www.jelix.org
+ * @licence     GNU Lesser General Public Licence see LICENCE file or http://www.gnu.org/licenses/lgpl.html
+ */
+use \Jelix\IniFile\IniModifier as IniModifier;
+use \Jelix\IniFile\MultiIniModifier as MultiIniModifier;
+
+require_once(__DIR__.'/lib.php');
+
+class IniModifierNumericGetTest extends PHPUnit_Framework_TestCase {
+
+    function testGetValue() {
+        $parser = new testIniFileModifier('foo.ini', '
+  ; a comment
+  
+foo=bar
+anumber=98
+anumber_string = "98"
+string= "uuuuu"
+string2= "aaa
+bbb"
+string3= "aaa
+  multiline
+bbb"
+afloatnumber=   5.098  
+afloatnumber_string = "5.098"
+
+[aSection]
+laurent=toto
+trucon = on
+machintrue = true
+bidule1 = 1
+chouetyes = yes
+trucoff = off
+machinfalse = false
+bidule0 = 0
+chouetno = no
+bizarre=none
+
+[othersection]
+truc=machin2
+
+[vla]
+foo[]=aaa
+foo[]=bbb
+foo[]=ccc
+
+[the_section]
+truck=on
+foo[key1]=aaa
+; key comment
+foo[key2]=true
+foo[key4]=off
+foo[key3]=ccc
+', IniModifier::PR_NUMERIC);
+
+        $this->assertEquals($parser->getValue('foo'), 'bar' );
+        $this->assertEquals($parser->getValue('anumber'), 98 );
+        $this->assertEquals($parser->getValue('anumber_string'), 98 );
+        $this->assertEquals($parser->getValue('string'), 'uuuuu' );
+        $this->assertEquals($parser->getValue('string2'), 'aaa
+bbb');
+        $this->assertEquals($parser->getValue('string3'), 'aaa
+  multiline
+bbb');
+        $this->assertEquals($parser->getValue('afloatnumber'), 5.098 );
+        $this->assertEquals($parser->getValue('afloatnumber_string'), 5.098 );
+        $this->assertEquals($parser->getValue('truc','aSection'), null );
+        $this->assertEquals($parser->getValue('laurent','aSection'), 'toto' );
+        $this->assertEquals($parser->getValue('trucon','aSection'), "on" );
+        $this->assertEquals($parser->getValue('machintrue','aSection'), "true" );
+        $this->assertEquals($parser->getValue('bidule1','aSection'), 1 );
+        $this->assertEquals($parser->getValue('chouetyes','aSection'), "yes" );
+        $this->assertEquals($parser->getValue('trucoff','aSection'), "off" );
+        $this->assertEquals($parser->getValue('machinfalse','aSection'), "false" );
+        $this->assertEquals($parser->getValue('bidule0','aSection'), 0 );
+        $this->assertEquals($parser->getValue('chouetno','aSection'), "no" );
+        $this->assertEquals($parser->getValue('bizarre','aSection'), "none" );
+        $this->assertEquals($parser->getValue('foo','vla',2), 'ccc' );
+        $this->assertEquals($parser->getValue('foo','vla'), array('aaa', 'bbb', 'ccc'));
+        $this->assertEquals($parser->getValue('foo','the_section'), array('key1'=>'aaa', 'key2'=>"true", 'key4'=>"off", 'key3'=>'ccc'));
+    }
+
+
+    public function testGetValues() {
+        $content = '
+; a comment <?php die()
+  
+foo=bar
+
+; section comment
+[aSection]
+trucon = on
+machintrue = true
+bidule1 = 1
+chouetyes = yes
+trucoff = off
+machinfalse = false
+bidule0 = 0
+chouetno = no
+bizarre=none
+
+; super section
+[the_section]
+truc=machin
+bidule=1
+truck=on
+foo[]=aaa
+; key comment
+foo[]=true
+foo[]=off
+foo[]=ccc
+
+
+';
+
+        $ini = new testIniFileModifier('foo.ini', $content, IniModifier::PR_NUMERIC);
+
+        $values = $ini->getValues('the_section');
+        $expected = array('truc'=>'machin', 'bidule'=>1, 'truck'=>"on", 'foo'=>array('aaa', "true", 'off', 'ccc'));
+        $this->assertEquals($expected, $values);
+
+        $values = $ini->getValues(0);
+        $expected = array('foo'=>'bar');
+        $this->assertEquals($expected, $values);
+
+        $values = $ini->getValues('aSection');
+        $expected = array(
+            'trucon' => "on",
+            'machintrue' => "true",
+            'bidule1' => 1,
+            'chouetyes' => "yes",
+            'trucoff' => "off",
+            'machinfalse' => "false",
+            'bidule0' => 0,
+            'chouetno' => "no",
+            'bizarre'=>"none",
+        );
+        $this->assertEquals($expected, $values);
+
+
+    }
+
+    public function testGetValuesAssocArray() {
+        $content = '
+; a comment <?php die()
+  
+foo=bar
+
+; section comment
+[aSection]
+truc=true
+
+; super section
+[the_section]
+truc=machin
+bidule=1
+truck=on
+foo[key1]=aaa
+; key comment
+foo[key2]=true
+foo[key4]=off
+foo[key3]=ccc
+';
+
+        $ini = new testIniFileModifier('foo.ini', $content, IniModifier::PR_NUMERIC);
+
+        $values = $ini->getValues('the_section');
+        $expected = array('truc'=>'machin', 'bidule'=>1, 'truck'=>"on", 'foo'=>array('key1'=>'aaa', 'key2'=>"true", 'key4'=>"off", 'key3'=>'ccc'));
+        $this->assertEquals($expected, $values);
+
+        $values = $ini->getValues(0);
+        $expected = array('foo'=>'bar');
+        $this->assertEquals($expected, $values);
+    }
+
+}

--- a/tests/IniModifierNumericSetTest.php
+++ b/tests/IniModifierNumericSetTest.php
@@ -10,7 +10,7 @@ use \Jelix\IniFile\MultiIniModifier as MultiIniModifier;
 
 require_once(__DIR__ . '/lib.php');
 
-class IniModifierSetTest extends PHPUnit_Framework_TestCase
+class IniModifierNumericSetTest extends PHPUnit_Framework_TestCase
 {
 
     protected function prepareParserSetValue()
@@ -52,7 +52,7 @@ truc=machin2
             ),
         );
 
-        $parser = new testIniFileModifier('foo.ini', $content);
+        $parser = new testIniFileModifier('foo.ini', $content, IniModifier::PR_NUMERIC);
 
         $this->assertEquals($expected, $parser->getContent());
         $this->assertFalse($parser->isModified());
@@ -63,13 +63,13 @@ truc=machin2
     {
         $parser = $this->prepareParserSetValue();
         // set Simple value
-        $parser->setValue('foo', 'hello');
+        $parser->setValue('foo', 3.14159);
         $expected = array(
             0 => array(
                 array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_COMMENT, "  ; a comment"),
                 array(IniModifier::TK_WS, "  "),
-                array(IniModifier::TK_VALUE, 'foo', 'hello'),
+                array(IniModifier::TK_VALUE, 'foo', 3.14159),
                 array(IniModifier::TK_WS, ""),
             ),
             'aSection' => array(
@@ -91,18 +91,18 @@ truc=machin2
         $parser->clearModifierFlag();
 
         // set value in a section
-        $parser->setValue('truc', 'bidule', 'aSection');
+        $parser->setValue('truc', 3.14159, 'aSection');
         $expected = array(
             0 => array(
                 array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_COMMENT, "  ; a comment"),
                 array(IniModifier::TK_WS, "  "),
-                array(IniModifier::TK_VALUE, 'foo', 'hello'),
+                array(IniModifier::TK_VALUE, 'foo', 3.14159),
                 array(IniModifier::TK_WS, ""),
             ),
             'aSection' => array(
                 array(IniModifier::TK_SECTION, "[aSection]"),
-                array(IniModifier::TK_VALUE, 'truc', 'bidule'),
+                array(IniModifier::TK_VALUE, 'truc', 3.14159),
                 array(IniModifier::TK_VALUE, 'flag', 'on'),
                 array(IniModifier::TK_VALUE, 'noflag', 'off'),
                 array(IniModifier::TK_WS, ""),
@@ -119,55 +119,27 @@ truc=machin2
         $parser->clearModifierFlag();
 
         // set value in an other section
-        $parser->setValue('truc', 'bidule2', 'othersection');
+        $parser->setValue('truc', 3.14159, 'othersection');
         $expected = array(
             0 => array(
                 array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_COMMENT, "  ; a comment"),
                 array(IniModifier::TK_WS, "  "),
-                array(IniModifier::TK_VALUE, 'foo', 'hello'),
+                array(IniModifier::TK_VALUE, 'foo', 3.14159),
                 array(IniModifier::TK_WS, ""),
             ),
             'aSection' => array(
                 array(IniModifier::TK_SECTION, "[aSection]"),
-                array(IniModifier::TK_VALUE, 'truc', 'bidule'),
+                array(IniModifier::TK_VALUE, 'truc', 3.14159),
                 array(IniModifier::TK_VALUE, 'flag', 'on'),
                 array(IniModifier::TK_VALUE, 'noflag', 'off'),
                 array(IniModifier::TK_WS, ""),
             ),
             'othersection' => array(
                 array(IniModifier::TK_SECTION, "[othersection]"),
-                array(IniModifier::TK_VALUE, 'truc', 'bidule2'),
+                array(IniModifier::TK_VALUE, 'truc', 3.14159),
                 array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_WS, ""),
-            ),
-        );
-        $this->assertEquals($expected, $parser->getContent());
-        $this->assertTrue($parser->isModified());
-        $parser->clearModifierFlag();
-
-        $parser->setValue('name', 'toto', 'othersection');
-        $expected = array(
-            0 => array(
-                array(IniModifier::TK_WS, ""),
-                array(IniModifier::TK_COMMENT, "  ; a comment"),
-                array(IniModifier::TK_WS, "  "),
-                array(IniModifier::TK_VALUE, 'foo', 'hello'),
-                array(IniModifier::TK_WS, ""),
-            ),
-            'aSection' => array(
-                array(IniModifier::TK_SECTION, "[aSection]"),
-                array(IniModifier::TK_VALUE, 'truc', 'bidule'),
-                array(IniModifier::TK_VALUE, 'flag', 'on'),
-                array(IniModifier::TK_VALUE, 'noflag', 'off'),
-                array(IniModifier::TK_WS, ""),
-            ),
-            'othersection' => array(
-                array(IniModifier::TK_SECTION, "[othersection]"),
-                array(IniModifier::TK_VALUE, 'truc', 'bidule2'),
-                array(IniModifier::TK_WS, ""),
-                array(IniModifier::TK_WS, ""),
-                array(IniModifier::TK_VALUE, 'name', 'toto'),
             ),
         );
         $this->assertEquals($expected, $parser->getContent());
@@ -180,8 +152,8 @@ truc=machin2
         $parser = $this->prepareParserSetValue();
         // set Simple value
         $parser->setValue('foo', 'bar');
-        $parser->setValue('flag', true, 'aSection');
-        $parser->setValue('noflag', false, 'aSection');
+        $parser->setValue('flag', 'on', 'aSection');
+        $parser->setValue('noflag', 'off', 'aSection');
         $expected = array(
             0 => array(
                 array(IniModifier::TK_WS, ""),
@@ -262,35 +234,6 @@ truc=machin2
         $this->assertTrue($parser->isModified());
 
         $parser = $this->prepareParserSetValue();
-        // set modified boolean value
-        $parser->setValue('flag', false, 'aSection');
-        $parser->setValue('noflag', true, 'aSection');
-        $expected = array(
-            0 => array(
-                array(IniModifier::TK_WS, ""),
-                array(IniModifier::TK_COMMENT, "  ; a comment"),
-                array(IniModifier::TK_WS, "  "),
-                array(IniModifier::TK_VALUE, 'foo', 'bar'),
-                array(IniModifier::TK_WS, ""),
-            ),
-            'aSection' => array(
-                array(IniModifier::TK_SECTION, "[aSection]"),
-                array(IniModifier::TK_VALUE, 'truc', 'machin'),
-                array(IniModifier::TK_VALUE, 'flag', false),
-                array(IniModifier::TK_VALUE, 'noflag', true),
-                array(IniModifier::TK_WS, ""),
-            ),
-            'othersection' => array(
-                array(IniModifier::TK_SECTION, "[othersection]"),
-                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
-                array(IniModifier::TK_WS, ""),
-                array(IniModifier::TK_WS, ""),
-            ),
-        );
-        $this->assertEquals($expected, $parser->getContent());
-        $this->assertTrue($parser->isModified());
-
-        $parser = $this->prepareParserSetValue();
         // set Simple value
         $parser->setValue('flag', 'off', 'aSection');
         $parser->setValue('noflag', 'on', 'aSection');
@@ -318,8 +261,8 @@ truc=machin2
         );
         $this->assertEquals($expected, $parser->getContent());
         $this->assertTrue($parser->isModified());
-        $this->assertFalse($parser->getValue('flag', 'aSection'));
-        $this->assertTrue($parser->getValue('noflag', 'aSection'));
+        $this->assertEquals($parser->getValue('flag', 'aSection'), 'off');
+        $this->assertEquals($parser->getValue('noflag', 'aSection'), 'on');
     }
 
 
@@ -346,9 +289,9 @@ truc=machin2
             'othersection' => array(
                 array(IniModifier::TK_SECTION, "[othersection]"),
                 array(IniModifier::TK_VALUE, 'truc', 'machin2'),
-                array(IniModifier::TK_WS, ""),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_ARR_VALUE, 'name', 'toto', 0),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
             ),
         );
         $this->assertEquals($expected, $parser->getContent());
@@ -370,15 +313,15 @@ truc=machin2
                 array(IniModifier::TK_VALUE, 'truc', 'machin'),
                 array(IniModifier::TK_VALUE, 'flag', 'on'),
                 array(IniModifier::TK_VALUE, 'noflag', 'off'),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_ARR_VALUE, 'theme', 'blue', 0),
+                array(IniModifier::TK_WS, ""),
             ),
             'othersection' => array(
                 array(IniModifier::TK_SECTION, "[othersection]"),
                 array(IniModifier::TK_VALUE, 'truc', 'machin2'),
-                array(IniModifier::TK_WS, ""),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_ARR_VALUE, 'name', 'toto', 0),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
             ),
         );
         $this->assertEquals($expected, $parser->getContent());
@@ -413,8 +356,8 @@ foo[]=machine
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
                 array(IniModifier::TK_VALUE, 'example', '1'),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 1),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'bla', 2),
+                array(IniModifier::TK_WS, ""),
             ),
         );
         $this->assertEquals($expected, $parser->getContent());
@@ -428,8 +371,8 @@ foo[]=machine
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
                 array(IniModifier::TK_VALUE, 'example', '1'),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 1),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'bla', 2),
+                array(IniModifier::TK_WS, ""),
             ),
             'aSection' => array(
                 array(IniModifier::TK_SECTION, "[aSection]"),
@@ -447,8 +390,8 @@ foo[]=machine
                 array(IniModifier::TK_VALUE, 'foo', 'button'),
                 array(IniModifier::TK_VALUE, 'example', '1'),
                 array(IniModifier::TK_WS, '--'),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_WS, '--'),
+                array(IniModifier::TK_WS, ""),
             ),
             'aSection' => array(
                 array(IniModifier::TK_SECTION, "[aSection]"),
@@ -484,9 +427,9 @@ foo[]=machine
             'othersection' => array(
                 array(IniModifier::TK_SECTION, "[othersection]"),
                 array(IniModifier::TK_VALUE, 'truc', 'machin2'),
-                array(IniModifier::TK_WS, ""),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_ARR_VALUE, 'name', 'toto', 0),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
             ),
         );
         $this->assertEquals($expected, $parser->getContent());
@@ -513,11 +456,11 @@ foo[]=machine
             'othersection' => array(
                 array(IniModifier::TK_SECTION, "[othersection]"),
                 array(IniModifier::TK_VALUE, 'truc', 'machin2'),
-                array(IniModifier::TK_WS, ""),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_ARR_VALUE, 'name', 'black', 0),
                 array(IniModifier::TK_ARR_VALUE, 'name', 'brown', 1),
                 array(IniModifier::TK_ARR_VALUE, 'name', 'yellow', 2),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
             ),
         );
         $this->assertEquals($expected, $parser->getContent());
@@ -544,11 +487,11 @@ foo[]=machine
             'othersection' => array(
                 array(IniModifier::TK_SECTION, "[othersection]"),
                 array(IniModifier::TK_VALUE, 'truc', 'machin2'),
-                array(IniModifier::TK_WS, ""),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_ARR_VALUE, 'name', 'red', 0),
                 array(IniModifier::TK_ARR_VALUE, 'name', 'white', 1),
                 array(IniModifier::TK_WS, '--'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
             ),
         );
         $this->assertEquals($expected, $parser->getContent());
@@ -593,8 +536,8 @@ truc=machin2
                 array(IniModifier::TK_VALUE, 'ddd', 'eee'),
                 array(IniModifier::TK_ARR_VALUE, 'mylist', 'brown', 1),
                 array(IniModifier::TK_VALUE, 'fff', 'ggg'),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_ARR_VALUE, 'mylist', 'yellow', 2),
+                array(IniModifier::TK_WS, ""),
             ),
             'othersection' => array(
                 array(IniModifier::TK_SECTION, "[othersection]"),
@@ -624,8 +567,8 @@ truc=machin2
                 array(IniModifier::TK_VALUE, 'ddd', 'eee'),
                 array(IniModifier::TK_WS, '--'),
                 array(IniModifier::TK_VALUE, 'fff', 'ggg'),
+                array(IniModifier::TK_WS, '--'),
                 array(IniModifier::TK_WS, ""),
-                array(IniModifier::TK_WS, '--')
             ),
             'othersection' => array(
                 array(IniModifier::TK_SECTION, "[othersection]"),
@@ -670,8 +613,8 @@ foo[]=vla
                 array(IniModifier::TK_VALUE, 'example', '1'),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 'key1'),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'vla', 2),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'bla', 'champ'),
+                array(IniModifier::TK_WS, ""),
             ),
         );
         $this->assertEquals($expected, $parser->getContent());
@@ -686,8 +629,8 @@ foo[]=vla
                 array(IniModifier::TK_VALUE, 'example', '1'),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'modif', 'key1'),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'vla', 2),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'bla', 'champ'),
+                array(IniModifier::TK_WS, ""),
             ),
         );
         $this->assertEquals($expected, $parser->getContent());
@@ -702,8 +645,8 @@ foo[]=vla
                 array(IniModifier::TK_VALUE, 'example', '1'),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'modif', 'key1'),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'vla', 2),
-                array(IniModifier::TK_WS, ""),
                 array(IniModifier::TK_ARR_VALUE, 'foo', 'modif2', 'champ'),
+                array(IniModifier::TK_WS, ""),
             ),
         );
         $this->assertEquals($expected, $parser->getContent());
@@ -747,7 +690,6 @@ truc=true
 
 ; super section
 [the_section]
-
 truc=machin
 bidule=1
 truck=on
@@ -777,7 +719,6 @@ assoc[otherkey]=bus
 foo[]=baz
 assoc[key1]=car
 assoc[otherkey]=bus
-
 foo[]="other value"
 foo[]=five
 assoc[ov]="other value"

--- a/tests/IniModifierRawGetTest.php
+++ b/tests/IniModifierRawGetTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * @author      Laurent Jouanneau
+ * @copyright   2008-2015 Laurent Jouanneau
+ * @link        http://www.jelix.org
+ * @licence     GNU Lesser General Public Licence see LICENCE file or http://www.gnu.org/licenses/lgpl.html
+ */
+use \Jelix\IniFile\IniModifier as IniModifier;
+use \Jelix\IniFile\MultiIniModifier as MultiIniModifier;
+
+require_once(__DIR__.'/lib.php');
+
+class IniModifierRawGetTest extends PHPUnit_Framework_TestCase {
+
+    function testGetValue() {
+        $parser = new testIniFileModifier('foo.ini', '
+  ; a comment
+  
+foo=bar
+anumber=98
+anumber_string = "98"
+string= "uuuuu"
+string2= "aaa
+bbb"
+string3= "aaa
+  multiline
+bbb"
+afloatnumber=   5.098  
+afloatnumber_string = "5.098"
+
+[aSection]
+laurent=toto
+trucon = on
+machintrue = true
+bidule1 = 1
+chouetyes = yes
+trucoff = off
+machinfalse = false
+bidule0 = 0
+chouetno = no
+bizarre=none
+
+[othersection]
+truc=machin2
+
+[vla]
+foo[]=aaa
+foo[]=bbb
+foo[]=ccc
+
+[the_section]
+truck=on
+foo[key1]=aaa
+; key comment
+foo[key2]=true
+foo[key4]=off
+foo[key3]=ccc
+', IniModifier::PR_RAW);
+
+        $this->assertEquals($parser->getValue('foo'), 'bar' );
+        $this->assertEquals($parser->getValue('anumber'), '98' );
+        $this->assertEquals($parser->getValue('anumber_string'), '98' );
+        $this->assertEquals($parser->getValue('string'), 'uuuuu' );
+        $this->assertEquals($parser->getValue('string2'), 'aaa
+bbb');
+        $this->assertEquals($parser->getValue('string3'), 'aaa
+  multiline
+bbb');
+        $this->assertEquals($parser->getValue('afloatnumber'), '5.098' );
+        $this->assertEquals($parser->getValue('afloatnumber_string'), '5.098' );
+        $this->assertEquals($parser->getValue('truc','aSection'), null );
+        $this->assertEquals($parser->getValue('laurent','aSection'), 'toto' );
+        $this->assertEquals($parser->getValue('trucon','aSection'), "on" );
+        $this->assertEquals($parser->getValue('machintrue','aSection'), "true" );
+        $this->assertEquals($parser->getValue('bidule1','aSection'), '1' );
+        $this->assertEquals($parser->getValue('chouetyes','aSection'), "yes" );
+        $this->assertEquals($parser->getValue('trucoff','aSection'), "off" );
+        $this->assertEquals($parser->getValue('machinfalse','aSection'), "false" );
+        $this->assertEquals($parser->getValue('bidule0','aSection'), '0' );
+        $this->assertEquals($parser->getValue('chouetno','aSection'), "no" );
+        $this->assertEquals($parser->getValue('bizarre','aSection'), "none" );
+        $this->assertEquals($parser->getValue('foo','vla',2), 'ccc' );
+        $this->assertEquals($parser->getValue('foo','vla'), array('aaa', 'bbb', 'ccc'));
+        $this->assertEquals($parser->getValue('foo','the_section'), array('key1'=>'aaa', 'key2'=>"true", 'key4'=>"off", 'key3'=>'ccc'));
+    }
+
+
+    public function testGetValues() {
+        $content = '
+; a comment <?php die()
+  
+foo=bar
+
+; section comment
+[aSection]
+trucon = on
+machintrue = true
+bidule1 = 1
+chouetyes = yes
+trucoff = off
+machinfalse = false
+bidule0 = 0
+chouetno = no
+bizarre=none
+
+; super section
+[the_section]
+truc=machin
+bidule=1
+truck=on
+foo[]=aaa
+; key comment
+foo[]=true
+foo[]=off
+foo[]=ccc
+
+
+';
+
+        $ini = new testIniFileModifier('foo.ini', $content, IniModifier::PR_RAW);
+
+        $values = $ini->getValues('the_section');
+        $expected = array('truc'=>'machin', 'bidule'=>'1', 'truck'=>"on", 'foo'=>array('aaa', "true", 'off', 'ccc'));
+        $this->assertEquals($expected, $values);
+
+        $values = $ini->getValues(0);
+        $expected = array('foo'=>'bar');
+        $this->assertEquals($expected, $values);
+
+        $values = $ini->getValues('aSection');
+        $expected = array(
+            'trucon' => "on",
+            'machintrue' => "true",
+            'bidule1' => '1',
+            'chouetyes' => "yes",
+            'trucoff' => "off",
+            'machinfalse' => "false",
+            'bidule0' => '0',
+            'chouetno' => "no",
+            'bizarre'=>"none",
+        );
+        $this->assertEquals($expected, $values);
+
+
+    }
+
+    public function testGetValuesAssocArray() {
+        $content = '
+; a comment <?php die()
+  
+foo=bar
+
+; section comment
+[aSection]
+truc=true
+
+; super section
+[the_section]
+truc=machin
+bidule=1
+truck=on
+foo[key1]=aaa
+; key comment
+foo[key2]=true
+foo[key4]=off
+foo[key3]=ccc
+';
+
+        $ini = new testIniFileModifier('foo.ini', $content, IniModifier::PR_RAW);
+
+        $values = $ini->getValues('the_section');
+        $expected = array('truc'=>'machin', 'bidule'=>'1', 'truck'=>"on", 'foo'=>array('key1'=>'aaa', 'key2'=>"true", 'key4'=>"off", 'key3'=>'ccc'));
+        $this->assertEquals($expected, $values);
+
+        $values = $ini->getValues(0);
+        $expected = array('foo'=>'bar');
+        $this->assertEquals($expected, $values);
+    }
+
+}

--- a/tests/IniModifierRawSetTest.php
+++ b/tests/IniModifierRawSetTest.php
@@ -1,0 +1,731 @@
+<?php
+/**
+ * @author      Laurent Jouanneau
+ * @copyright   2008-2016 Laurent Jouanneau
+ * @link        http://www.jelix.org
+ * @licence     GNU Lesser General Public Licence see LICENCE file or http://www.gnu.org/licenses/lgpl.html
+ */
+use \Jelix\IniFile\IniModifier as IniModifier;
+use \Jelix\IniFile\MultiIniModifier as MultiIniModifier;
+
+require_once(__DIR__ . '/lib.php');
+
+class IniModifierRawSetTest extends PHPUnit_Framework_TestCase
+{
+
+    protected function prepareParserSetValue()
+    {
+        $content = '
+  ; a comment
+  
+foo=bar
+
+[aSection]
+truc=machin
+flag=on
+noflag=off
+
+[othersection]
+truc=machin2
+
+';
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $parser = new testIniFileModifier('foo.ini', $content, IniModifier::PR_RAW);
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertFalse($parser->isModified());
+        return $parser;
+    }
+
+    function testSetValue()
+    {
+        $parser = $this->prepareParserSetValue();
+        // set Simple value
+        $parser->setValue('foo', 3.14159);
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', '3.14159'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // set value in a section
+        $parser->setValue('truc', 3.14159, 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', '3.14159'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', '3.14159'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // set value in an other section
+        $parser->setValue('truc', 3.14159, 'othersection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', '3.14159'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', '3.14159'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', '3.14159'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+
+    function testSetExistingValue()
+    {
+        $parser = $this->prepareParserSetValue();
+        // set Simple value
+        $parser->setValue('foo', 'bar');
+        $parser->setValue('flag', 'on', 'aSection');
+        $parser->setValue('noflag', 'off', 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertFalse($parser->isModified());
+
+        // set same value in a section
+        $parser->setValue('truc', 'machin', 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertFalse($parser->isModified());
+
+        // set modified value in a section
+        $parser->setValue('truc', 'bidule', 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'bidule'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+
+        $parser = $this->prepareParserSetValue();
+        // set Simple value
+        $parser->setValue('flag', 'off', 'aSection');
+        $parser->setValue('noflag', 'on', 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'off'),
+                array(IniModifier::TK_VALUE, 'noflag', 'on'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $this->assertEquals($parser->getValue('flag', 'aSection'), 'off');
+        $this->assertEquals($parser->getValue('noflag', 'aSection'), 'on');
+    }
+
+
+    function testSetArrayValue()
+    {
+        $parser = $this->prepareParserSetValue();
+        // append an array value
+        $parser->setValue('name', 'toto', 'othersection', '');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'toto', 0),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // append an array value at the 0 key
+        $parser->setValue('theme', 'blue', 'aSection', 0);
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_ARR_VALUE, 'theme', 'blue', 0),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'toto', 0),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+
+    function testSetArrayValue2()
+    {
+        $content = '
+foo[]=bar
+example=1
+foo[]=machine
+';
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 1),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $parser = new testIniFileModifier('foo.ini', $content);
+        $this->assertEquals($expected, $parser->getContent());
+
+        $parser->setValue('foo', 'bla', 0, '');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 1),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bla', 2),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        $parser->setValue('theme', 'blue', 'aSection', '0');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 1),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bla', 2),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_ARR_VALUE, 'theme', 'blue', 0),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        $parser->setValue('foo', 'button');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_VALUE, 'foo', 'button'),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_WS, '--'),
+                array(IniModifier::TK_WS, '--'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_ARR_VALUE, 'theme', 'blue', 0),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+
+
+    function testSetArrayValueWithArray()
+    {
+        $parser = $this->prepareParserSetValue();
+        // append an array value
+        $parser->setValue('name', 'toto', 'othersection', '');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'toto', 0),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // now set a new value which is an array
+        $parser->setValue('name', array('black', 'brown', 'yellow'), 'othersection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'black', 0),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'brown', 1),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'yellow', 2),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // now change it by a smaller array
+        $parser->setValue('name', array('red', 'white'), 'othersection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'red', 0),
+                array(IniModifier::TK_ARR_VALUE, 'name', 'white', 1),
+                array(IniModifier::TK_WS, '--'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+
+    function testModifyArrayValueWithArray()
+    {
+        $content = '
+  ; a comment
+  
+foo=bar
+
+[aSection]
+truc=machin
+mylist[]=hello
+ddd=eee
+mylist[]=bar
+fff=ggg
+
+[othersection]
+truc=machin2
+
+';
+        $parser = new testIniFileModifier('foo.ini', $content);
+
+        // now set a new value which is an array
+        $parser->setValue('mylist', array('black', 'brown', 'yellow'), 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_ARR_VALUE, 'mylist', 'black', 0),
+                array(IniModifier::TK_VALUE, 'ddd', 'eee'),
+                array(IniModifier::TK_ARR_VALUE, 'mylist', 'brown', 1),
+                array(IniModifier::TK_VALUE, 'fff', 'ggg'),
+                array(IniModifier::TK_ARR_VALUE, 'mylist', 'yellow', 2),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // now change it by a smaller array
+        $parser->setValue('mylist', array('red'), 'aSection');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "  ; a comment"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_ARR_VALUE, 'mylist', 'red', 0),
+                array(IniModifier::TK_VALUE, 'ddd', 'eee'),
+                array(IniModifier::TK_WS, '--'),
+                array(IniModifier::TK_VALUE, 'fff', 'ggg'),
+                array(IniModifier::TK_WS, '--'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+    }
+
+    function testSetAssocArrayValue()
+    {
+        $content = '
+foo[]=bar
+example=1
+foo[key1]=machine
+foo[]=vla
+';
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 'key1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'vla', 2),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $parser = new testIniFileModifier('foo.ini', $content);
+        $this->assertEquals($expected, $parser->getContent());
+
+        $parser->setValue('foo', 'bla', 0, 'champ');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'machine', 'key1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'vla', 2),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bla', 'champ'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        $parser->setValue('foo', 'modif', 0, 'key1');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'modif', 'key1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'vla', 2),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bla', 'champ'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        $parser->setValue('foo', 'modif2', 0, 'champ');
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'bar', 0),
+                array(IniModifier::TK_VALUE, 'example', '1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'modif', 'key1'),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'vla', 2),
+                array(IniModifier::TK_ARR_VALUE, 'foo', 'modif2', 'champ'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+
+
+    public function testSetValues() {
+        $content = '
+; a comment <?php die()
+  
+foo=bar
+
+; section comment
+[aSection]
+truc=true
+
+; super section
+[the_section]
+foo= z
+';
+        $ini = new testIniFileModifier('foo.ini', $content);
+        $ini->setValues(
+            array(
+                'truc'=>'machin',
+                'bidule'=>1,
+                'truck'=>true,
+                'notruck'=>false,
+                'foo'=>array('aaa', 'bbb', 'machin'=>'ccc')
+            ),
+            'the_section');
+        $expected = '
+; a comment <?php die()
+  
+foo=bar
+
+; section comment
+[aSection]
+truc=true
+
+; super section
+[the_section]
+truc=machin
+bidule=1
+truck=on
+notruck=off
+foo[]=aaa
+foo[]=bbb
+foo[machin]=ccc
+';
+        $this->assertEquals($expected, $ini->generate());
+        $this->assertTrue($ini->isModified());
+        $ini->clearModifierFlag();
+    }
+
+
+
+    public function testSetExample() {
+        $content = 'foo[]=bar
+foo[]=baz
+assoc[key1]=car
+assoc[otherkey]=bus
+';
+        $ini = new testIniFileModifier('foo.ini', $content);
+        $ini->setValue('foo', 'other value', 0, '');
+        $ini->setValue('foo', 'five', 0, 5);
+        $ini->setValue('assoc', 'other value', 0, 'ov');
+        $expected = 'foo[]=bar
+foo[]=baz
+assoc[key1]=car
+assoc[otherkey]=bus
+foo[]="other value"
+foo[]=five
+assoc[ov]="other value"
+';
+        $this->assertEquals($expected, $ini->generate());
+        $this->assertTrue($ini->isModified());
+        $ini->clearModifierFlag();
+    }
+
+}

--- a/tests/IniModifierRemoveCommentsTest.php
+++ b/tests/IniModifierRemoveCommentsTest.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * @author      Laurent Jouanneau
+ * @copyright   2008-2015 Laurent Jouanneau
+ * @link        http://www.jelix.org
+ * @licence     GNU Lesser General Public Licence see LICENCE file or http://www.gnu.org/licenses/lgpl.html
+ */
+use \Jelix\IniFile\IniModifier as IniModifier;
+use \Jelix\IniFile\MultiIniModifier as MultiIniModifier;
+
+require_once(__DIR__.'/lib.php');
+
+class IniModifierRemoveCommentsTest extends PHPUnit_Framework_TestCase {
+
+    protected function prepareParserRemoveComments()
+    {
+        $content = '
+; global foo comment  
+  
+foo=bar
+
+[aSection]
+; truc comment
+truc=machin
+; flag comment 1
+; flag comment 2
+flag=on
+; bedo a comment
+bedo[a] = "bedo a"
+; bedo b comment
+bedo[b] = "bedo b"
+noflag=off
+';
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "; global foo comment  "),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_COMMENT, "; truc comment"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_COMMENT, "; flag comment 1"),
+                array(IniModifier::TK_COMMENT, "; flag comment 2"),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_COMMENT, "; bedo a comment"),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo a', 'a'),
+                array(IniModifier::TK_COMMENT, "; bedo b comment"),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo b', 'b'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $parser = new testIniFileModifier('foo.ini', $content);
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertFalse($parser->isModified());
+        return $parser;
+    }
+
+    function testRemoveComments()
+    {
+        $parser = $this->prepareParserRemoveComments();
+
+        // remove single comment - global
+        $parser->removeComments('foo');
+
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_COMMENT, "; truc comment"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_COMMENT, "; flag comment 1"),
+                array(IniModifier::TK_COMMENT, "; flag comment 2"),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_COMMENT, "; bedo a comment"),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo a', 'a'),
+                array(IniModifier::TK_COMMENT, "; bedo b comment"),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo b', 'b'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // remove single comment
+        $parser->removeComments('truc', 'aSection');
+
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_COMMENT, "; flag comment 1"),
+                array(IniModifier::TK_COMMENT, "; flag comment 2"),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_COMMENT, "; bedo a comment"),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo a', 'a'),
+                array(IniModifier::TK_COMMENT, "; bedo b comment"),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo b', 'b'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // remove multiline comment
+        $parser->removeComments('flag', 'aSection');
+
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_COMMENT, "; bedo a comment"),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo a', 'a'),
+                array(IniModifier::TK_COMMENT, "; bedo b comment"),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo b', 'b'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // remove single comment with key
+        $parser->removeComments('bedo', 'aSection', 'b');
+
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_COMMENT, "; bedo a comment"),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo a', 'a'),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo b', 'b'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+}

--- a/tests/IniModifierSetCommentsTest.php
+++ b/tests/IniModifierSetCommentsTest.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * @author      Laurent Jouanneau
+ * @copyright   2008-2015 Laurent Jouanneau
+ * @link        http://www.jelix.org
+ * @licence     GNU Lesser General Public Licence see LICENCE file or http://www.gnu.org/licenses/lgpl.html
+ */
+use \Jelix\IniFile\IniModifier as IniModifier;
+use \Jelix\IniFile\MultiIniModifier as MultiIniModifier;
+
+require_once(__DIR__.'/lib.php');
+
+class IniModifierSetCommentsTest extends PHPUnit_Framework_TestCase {
+
+    protected function prepareParserSetComments()
+    {
+        $content = '
+; global foo comment  
+  
+foo=bar
+
+[aSection]
+truc=machin
+; flag comment
+flag=on
+noflag=off
+
+[othersection]
+truc=machin2
+
+';
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "; global foo comment  "),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_COMMENT, "; flag comment"),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $parser = new testIniFileModifier('foo.ini', $content);
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertFalse($parser->isModified());
+        return $parser;
+    }
+
+    function testSetComments()
+    {
+        $parser = $this->prepareParserSetComments();
+
+        // set single comment - global
+        $parser->setComments('foo', "; new global foo comment");
+
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_COMMENT, "; new global foo comment"),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_COMMENT, "; flag comment"),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // set single comment - in section
+        $parser->setComments('truc', "truc comment", 'aSection');
+
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_COMMENT, "; new global foo comment"),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_COMMENT, ";truc comment"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_COMMENT, "; flag comment"),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+
+        // set multiline comment
+        $parser->setComments('truc', ["othersection truc line 1" , "othersection truc line 2"], 'othersection');
+
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, "--"),
+                array(IniModifier::TK_WS, "  "),
+                array(IniModifier::TK_COMMENT, "; new global foo comment"),
+                array(IniModifier::TK_VALUE, 'foo', 'bar'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_COMMENT, ";truc comment"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin'),
+                array(IniModifier::TK_COMMENT, "; flag comment"),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'othersection' => array(
+                array(IniModifier::TK_SECTION, "[othersection]"),
+                array(IniModifier::TK_COMMENT, ";othersection truc line 1"),
+                array(IniModifier::TK_COMMENT, ";othersection truc line 2"),
+                array(IniModifier::TK_VALUE, 'truc', 'machin2'),
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+
+    protected function prepareParserSetCommentsWithKey()
+    {
+        $content = '
+bedo[a]="bedo a"
+bedo[b]="bedo b"
+
+[aSection]
+truc[a]="machin a"
+truc[b]="machin b"
+; flag comment
+flag=on
+noflag=off
+';
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo a', 'a'),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo b', 'b'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_ARR_VALUE, 'truc', 'machin a', 'a'),
+                array(IniModifier::TK_ARR_VALUE, 'truc', 'machin b', 'b'),
+                array(IniModifier::TK_COMMENT, "; flag comment"),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $parser = new testIniFileModifier('foo.ini', $content);
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertFalse($parser->isModified());
+        return $parser;
+    }
+
+    function testSetCommentsWithKey()
+    {
+        $parser = $this->prepareParserSetCommentsWithKey();
+
+        // set single comment - global
+        $parser->setComments('bedo', "; bedo a comment", 0, 'a');
+
+        $expected = array(
+            0 => array(
+                array(IniModifier::TK_WS, ""),
+                array(IniModifier::TK_COMMENT, "; bedo a comment"),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo a', 'a'),
+                array(IniModifier::TK_ARR_VALUE, 'bedo', 'bedo b', 'b'),
+                array(IniModifier::TK_WS, ""),
+            ),
+            'aSection' => array(
+                array(IniModifier::TK_SECTION, "[aSection]"),
+                array(IniModifier::TK_ARR_VALUE, 'truc', 'machin a', 'a'),
+                array(IniModifier::TK_ARR_VALUE, 'truc', 'machin b', 'b'),
+                array(IniModifier::TK_COMMENT, "; flag comment"),
+                array(IniModifier::TK_VALUE, 'flag', 'on'),
+                array(IniModifier::TK_VALUE, 'noflag', 'off'),
+                array(IniModifier::TK_WS, ""),
+            ),
+        );
+
+        $this->assertEquals($expected, $parser->getContent());
+        $this->assertTrue($parser->isModified());
+        $parser->clearModifierFlag();
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -3,9 +3,15 @@
   <testsuites>
     <testsuite name="Ini tools">
       <file>IniModifierTest.php</file>
-      <file>IniModifierSetTest.php</file>
-      <file>IniModifierGetTest.php</file>
+      <file>IniModifierNormalSetTest.php</file>
+      <file>IniModifierNumericSetTest.php</file>
+      <file>IniModifierRawSetTest.php</file>
+      <file>IniModifierNormalGetTest.php</file>
+      <file>IniModifierNumericGetTest.php</file>
+      <file>IniModifierRawGetTest.php</file>
       <file>IniModifierRemoveTest.php</file>
+      <file>IniModifierSetCommentsTest.php</file>
+      <file>IniModifierRemoveCommentsTest.php</file>
       <file>IniModifierRenameTest.php</file>
       <file>IniModifierImportTest.php</file>
       <file>MultiIniModifierTest.php</file>


### PR DESCRIPTION
This is my attempt at adding the following additional capabilities:
  - set / remove comment lines
  - set parsing mode
    - PR_NORMAL: the original behaviour, parsing "on"/"true"/"yes" to PHP true, etc
    - PR_NUMERIC: parsing to integer / float values only numeric values
    - PR_RAW: setting all values to string format with quotes 

I changed just one single behaviour: adding a parameter to a section will put it *before* blank lines. This is to consistently use blank lines as separator between sections, which is in my opinion desirable for readability.
